### PR TITLE
Add support for password in `remote` targets

### DIFF
--- a/targets/remote.py
+++ b/targets/remote.py
@@ -16,6 +16,7 @@ class Remote:
         user = target.get('user')
         host = target.get('host')
         port = target.get('port', 22)
+        password = target.get('password')
 
         print('')
         print(CBOLD + LGREEN, "Connecting to {}@{}:{}...".format(user, host, port), CRESET)
@@ -30,6 +31,7 @@ class Remote:
                 host=host,
                 username=target.get('user'),
                 port=port,
+                password=password,
                 cnopts=cnopts
             )
 

--- a/targets/remote.py
+++ b/targets/remote.py
@@ -17,6 +17,16 @@ class Remote:
         host = target.get('host')
         port = target.get('port', 22)
         password = target.get('password')
+        password_file = target.get('password_file')
+
+        if password_file:
+            try :
+                with open(password_file, 'rt') as file:
+                    password = file.read().strip('\r\n')
+            except OSError as e:
+                print(CBOLD, "Unable to open password file", CRESET)
+                print(traceback.format_exc())
+                return e, traceback
 
         print('')
         print(CBOLD + LGREEN, "Connecting to {}@{}:{}...".format(user, host, port), CRESET)


### PR DESCRIPTION
Add support for specifying a password for `remote` targets. The password can be provided in the `password` key.

It can also be written to a file on disk and the path to that file can be provided in the `password_file` key. This prevents the password from appearing in clear in the config file.

The README might need to be updated if you merge this.